### PR TITLE
Re-rewrite the listen_for decorator

### DIFF
--- a/discord/ext/events/custom_events/__init__.py
+++ b/discord/ext/events/custom_events/__init__.py
@@ -1,6 +1,5 @@
 from typing import Callable, Dict
-from . import member_kick
 
-_ALL: Dict[str, Callable] = {
-    member_kick.EVENT_NAME: member_kick.EVENT_CALLABLE,
-}
+# Filled at run time
+_ALL: Dict[str, Callable] = {}
+

--- a/discord/ext/events/custom_events/member_kick.py
+++ b/discord/ext/events/custom_events/member_kick.py
@@ -1,6 +1,6 @@
 import discord
 
-from ..utils import fetch_recent_audit_log_entry, listens_for, SENTINEL
+from ..utils import fetch_recent_audit_log_entry, listens_for
 
 
 @listens_for('member_remove')
@@ -8,10 +8,10 @@ async def check_member_kick(client: discord.Client, member: discord.Member):
     guild = member.guild
 
     if not guild.me.guild_permissions.view_audit_log:
-        return SENTINEL
+        return
 
     entry = await fetch_recent_audit_log_entry(client, member.guild, target=member, action=discord.AuditLogAction.kick, retry=3)
     if entry is None:
-        return SENTINEL
+        return
 
     return member, entry

--- a/discord/ext/events/custom_events/member_kick.py
+++ b/discord/ext/events/custom_events/member_kick.py
@@ -1,20 +1,17 @@
 import discord
 
-from ..utils import fetch_recent_audit_log_entry, listens_for
+from ..utils import fetch_recent_audit_log_entry, listens_for, SENTINEL
 
-EVENT_NAME = 'member_kick'
 
 @listens_for('member_remove')
 async def check_member_kick(client: discord.Client, member: discord.Member):
     guild = member.guild
 
     if not guild.me.guild_permissions.view_audit_log:
-        return
+        return SENTINEL
 
     entry = await fetch_recent_audit_log_entry(client, member.guild, target=member, action=discord.AuditLogAction.kick, retry=3)
     if entry is None:
-        return
+        return SENTINEL
 
-    client.dispatch(EVENT_NAME, member, entry)
-
-EVENT_CALLABLE = check_member_kick
+    return member, entry

--- a/discord/ext/events/utils.py
+++ b/discord/ext/events/utils.py
@@ -77,7 +77,9 @@ def listens_for(*events: str) -> Callable:
             if event in events:
                 result = await func(client, *args, **kwargs)
                 if result is not SENTINEL:
-                    client.dispatch(event_name, result)
+                    if not isinstance(result, tuple):
+                        result = (result,)
+                    client.dispatch(event_name, *result)
 
         return wrapper
 

--- a/discord/ext/events/utils.py
+++ b/discord/ext/events/utils.py
@@ -1,10 +1,11 @@
 import asyncio
 import datetime
-
 from functools import wraps
 from typing import Callable, Optional
 
 import discord
+
+from .custom_events import _ALL
 
 
 SLEEP_FOR = 2.5
@@ -68,12 +69,19 @@ def listens_for(*events: str) -> Callable:
     """
 
     def decorator(func: Callable) -> Callable:
+        event_name = func.__name__[6:]
+        _ALL[event_name] = func
 
         @wraps(func)
         async def wrapper(client, event, *args, **kwargs):
             if event in events:
-                await func(client, *args, **kwargs)
+                result = await func(client, *args, **kwargs)
+                if result is not SENTINEL:
+                    client.dispatch(event_name, result)
 
         return wrapper
 
     return decorator
+
+
+SENTINEL = object()

--- a/discord/ext/events/utils.py
+++ b/discord/ext/events/utils.py
@@ -76,7 +76,7 @@ def listens_for(*events: str) -> Callable:
         async def wrapper(client, event, *args, **kwargs):
             if event in events:
                 result = await func(client, *args, **kwargs)
-                if result is not SENTINEL:
+                if result is not None:
                     if not isinstance(result, tuple):
                         result = (result,)
                     client.dispatch(event_name, *result)
@@ -84,6 +84,3 @@ def listens_for(*events: str) -> Callable:
         return wrapper
 
     return decorator
-
-
-SENTINEL = object()


### PR DESCRIPTION
### Description
Rewrites the `listen_for` decorator to use the listener's name and return values to dispatch events inside the decorator.

```py
@listens_for('member_remove')
async def check_member_kick(client: discord.Client, member: discord.Member):
    ...
    client.dispatch(EVENT_NAME, member, entry)

EVENT_NAME = 'member_kick'
EVENT_CALLABLE = check_member_kick
```
goes to
```py
@listens_for('member_remove')
async def check_member_kick(client: discord.Client, member: discord.Member):
    ...
    return member, entry
```

### Checklist
<!-- put an x inside [ ] to check it, like so: [x] -->

- [x] This PR makes changes to the code.
    - [ ] The changes are breaking.
    - [ ] The changes implement a new feature.
    - [ ] The changes fix an issue.
    - [ ] I updated the documentation to reflect these changes.
- [ ] This PR makes changes to the documentation.
    - [ ] The changes require a different version of sphinx.
    - [ ] I updated the configuration file to reflect these changes.
- [x] This PR has been tested.
